### PR TITLE
Update Main.java

### DIFF
--- a/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
+++ b/plugin-management-cli/src/main/java/io/jenkins/tools/pluginmanager/cli/Main.java
@@ -13,6 +13,12 @@ import org.kohsuke.args4j.ParserProperties;
 
 public class Main {
     @SuppressFBWarnings("DM_EXIT")
+    
+    /*  The `@SuppressFBWarnings("DM_EXIT")` annotation is used to
+        suppress FindBugs warnings related to direct use of `System.exit()`.
+        Since the purpose of its usage is deliberate by the developer.
+    */
+    
     public static void main(String[] args) throws IOException {
         CliOptions options = new CliOptions();
         ParserProperties parserProperties = ParserProperties.defaults().withUsageWidth(150);


### PR DESCRIPTION
docs: Add explanation for the usage of @SuppressFBWarnings("DM_EXIT")

Provide a detailed comment explaining the purpose of the @SuppressFBWarnings("DM_EXIT") annotation in the code. The comment emphasizes that this deliberate usage is made with developer intent. This information enhances code readability and clarifies the rationale behind using System.exit() in specific situations.